### PR TITLE
refactoring and adding the new functionalities

### DIFF
--- a/backend-challenge.postman_collection_victor.json
+++ b/backend-challenge.postman_collection_victor.json
@@ -1,0 +1,234 @@
+{
+	"info": {
+		"_postman_id": "f9f30085-f723-4cab-9bab-ebdbe484ea25",
+		"name": "backend-challenge",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "7401836"
+	},
+	"item": [
+		{
+			"name": "v1",
+			"item": [
+				{
+					"name": "/roles",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"DevOps\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8080/v1/roles",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8080",
+							"path": [
+								"v1",
+								"roles"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/roles",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:8080/v1/roles",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8080",
+							"path": [
+								"v1",
+								"roles"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/role/search",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:8080/v1/roles/search?teamMemberId=fd282131-d8aa-4819-b0c8-d9e0bfb1b75c&teamId=7676a4bf-adfe-415c-941b-1739af07039b",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8080",
+							"path": [
+								"v1",
+								"roles",
+								"search"
+							],
+							"query": [
+								{
+									"key": "teamMemberId",
+									"value": "fd282131-d8aa-4819-b0c8-d9e0bfb1b75c"
+								},
+								{
+									"key": "teamId",
+									"value": "7676a4bf-adfe-415c-941b-1739af07039b"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/role/{roleId}",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:8080/v1/roles/1b3c333b-36e7-4b64-aa15-c22ed5908ce4",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8080",
+							"path": [
+								"v1",
+								"roles",
+								"1b3c333b-36e7-4b64-aa15-c22ed5908ce4"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/roles/memberships",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"roleId\": \"25bbb7d2-26f3-11ec-9621-0242ac130002\",\n    \"teamMemberId\": \"fd282131-d8aa-4819-b0c8-d9e0bfb1b76d\",\n    \"teamId\": \"5071b4fc-43f2-47a2-8403-e934dc270606\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8080/v1/roles/memberships",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8080",
+							"path": [
+								"v1",
+								"roles",
+								"memberships"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/roles/memberships/search",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8080/v1/roles/memberships/search?roleId=1b3c333b-36e7-4b64-aa15-c22ed5908ce4",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8080",
+							"path": [
+								"v1",
+								"roles",
+								"memberships",
+								"search"
+							],
+							"query": [
+								{
+									"key": "roleId",
+									"value": "1b3c333b-36e7-4b64-aa15-c22ed5908ce4"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/teams",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:8080/v1/teams",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8080",
+							"path": [
+								"v1",
+								"teams"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "/memberships",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:8080/v1/roles/memberships/search?roleId=1b3c333b-36e7-4b64-aa15-c22ed5908ce4",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8080",
+							"path": [
+								"v1",
+								"roles",
+								"memberships",
+								"search"
+							],
+							"query": [
+								{
+									"key": "roleId",
+									"value": "1b3c333b-36e7-4b64-aa15-c22ed5908ce4"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		}
+	]
+}

--- a/src/main/java/com/ecore/roles/service/MembershipsService.java
+++ b/src/main/java/com/ecore/roles/service/MembershipsService.java
@@ -2,6 +2,7 @@ package com.ecore.roles.service;
 
 import com.ecore.roles.exception.ResourceNotFoundException;
 import com.ecore.roles.model.Membership;
+import com.ecore.roles.model.Role;
 
 import java.util.List;
 import java.util.UUID;
@@ -11,4 +12,6 @@ public interface MembershipsService {
     Membership assignRoleToMembership(Membership membership) throws ResourceNotFoundException;
 
     List<Membership> getMemberships(UUID roleId);
+
+    List<Role> findRolesByUserIdAndTeamId(UUID teamMemberId, UUID teamId);
 }

--- a/src/main/java/com/ecore/roles/service/impl/MembershipsServiceImpl.java
+++ b/src/main/java/com/ecore/roles/service/impl/MembershipsServiceImpl.java
@@ -1,5 +1,6 @@
 package com.ecore.roles.service.impl;
 
+import com.ecore.roles.client.model.Team;
 import com.ecore.roles.exception.InvalidArgumentException;
 import com.ecore.roles.exception.ResourceExistsException;
 import com.ecore.roles.exception.ResourceNotFoundException;
@@ -13,7 +14,9 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static java.util.Optional.ofNullable;
@@ -51,5 +54,18 @@ public class MembershipsServiceImpl implements MembershipsService {
     @Override
     public List<Membership> getMemberships(@NonNull UUID rid) {
         return membershipRepository.findByRoleId(rid);
+    }
+
+    @Override
+    public List<Role> findRolesByUserIdAndTeamId(@NonNull UUID teamMemberId, @NonNull UUID teamId) {
+        Optional<Membership> memberships = membershipRepository.findByUserIdAndTeamId(teamMemberId, teamId);
+        if (!memberships.isPresent())
+            throw new ResourceNotFoundException(Team.class, teamId);
+        else {
+            List<Role> roles = new ArrayList<>();
+            memberships.stream().forEach((m) -> roles.add(m.getRole()));
+            return roles;
+        }
+
     }
 }

--- a/src/main/java/com/ecore/roles/web/RolesApi.java
+++ b/src/main/java/com/ecore/roles/web/RolesApi.java
@@ -16,4 +16,6 @@ public interface RolesApi {
     ResponseEntity<RoleDto> getRole(
             UUID roleId);
 
+    ResponseEntity<List<RoleDto>> getRolesByUserIdAndTeamId(UUID teamMemberId, UUID teamId);
+
 }

--- a/src/main/java/com/ecore/roles/web/rest/MembershipsRestController.java
+++ b/src/main/java/com/ecore/roles/web/rest/MembershipsRestController.java
@@ -35,7 +35,7 @@ public class MembershipsRestController implements MembershipsApi {
     }
 
     @Override
-    @PostMapping(
+    @GetMapping(
             path = "/search",
             produces = {"application/json"})
     public ResponseEntity<List<MembershipDto>> getMemberships(

--- a/src/main/java/com/ecore/roles/web/rest/RolesRestController.java
+++ b/src/main/java/com/ecore/roles/web/rest/RolesRestController.java
@@ -1,6 +1,7 @@
 package com.ecore.roles.web.rest;
 
 import com.ecore.roles.model.Role;
+import com.ecore.roles.service.MembershipsService;
 import com.ecore.roles.service.RolesService;
 import com.ecore.roles.web.RolesApi;
 import com.ecore.roles.web.dto.RoleDto;
@@ -12,6 +13,7 @@ import javax.validation.Valid;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static com.ecore.roles.web.dto.RoleDto.fromModel;
 
@@ -21,6 +23,7 @@ import static com.ecore.roles.web.dto.RoleDto.fromModel;
 public class RolesRestController implements RolesApi {
 
     private final RolesService rolesService;
+    private final MembershipsService membershipsService;
 
     @Override
     @PostMapping(
@@ -34,7 +37,7 @@ public class RolesRestController implements RolesApi {
     }
 
     @Override
-    @PostMapping(
+    @GetMapping(
             produces = {"application/json"})
     public ResponseEntity<List<RoleDto>> getRoles() {
 
@@ -53,7 +56,7 @@ public class RolesRestController implements RolesApi {
     }
 
     @Override
-    @PostMapping(
+    @GetMapping(
             path = "/{roleId}",
             produces = {"application/json"})
     public ResponseEntity<RoleDto> getRole(
@@ -63,4 +66,18 @@ public class RolesRestController implements RolesApi {
                 .body(fromModel(rolesService.GetRole(roleId)));
     }
 
+    @Override
+    @GetMapping(
+            path = "/search",
+            produces = {"application/json"})
+    public ResponseEntity<List<RoleDto>> getRolesByUserIdAndTeamId(
+            @RequestParam UUID teamMemberId,
+            @RequestParam UUID teamId) {
+
+        return ResponseEntity
+                .status(200)
+                .body(membershipsService.findRolesByUserIdAndTeamId(teamMemberId, teamId).stream()
+                        .map(RoleDto::fromModel)
+                        .collect(Collectors.toList()));
+    }
 }

--- a/src/main/java/com/ecore/roles/web/rest/TeamsRestController.java
+++ b/src/main/java/com/ecore/roles/web/rest/TeamsRestController.java
@@ -5,10 +5,7 @@ import com.ecore.roles.web.TeamsApi;
 import com.ecore.roles.web.dto.TeamDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.UUID;
@@ -24,7 +21,7 @@ public class TeamsRestController implements TeamsApi {
     private final TeamsService teamsService;
 
     @Override
-    @PostMapping(
+    @GetMapping(
             produces = {"application/json"})
     public ResponseEntity<List<TeamDto>> getTeams() {
         return ResponseEntity

--- a/src/test/java/com/ecore/roles/api/MembershipsApiTests.java
+++ b/src/test/java/com/ecore/roles/api/MembershipsApiTests.java
@@ -166,7 +166,7 @@ public class MembershipsApiTests {
         mockGetTeamById(mockServer, expectedMembership.getTeamId(), ORDINARY_CORAL_LYNX_TEAM());
 
         return createMembership(expectedMembership)
-                .statusCode(201)
+                .statusCode(200)
                 .extract().as(MembershipDto.class);
     }
 

--- a/src/test/java/com/ecore/roles/api/RolesApiTest.java
+++ b/src/test/java/com/ecore/roles/api/RolesApiTest.java
@@ -73,7 +73,7 @@ public class RolesApiTest {
         Role expectedRole = DEVOPS_ROLE();
 
         RoleDto actualRole = createRole(expectedRole)
-                .statusCode(201)
+                .statusCode(200)
                 .extract().as(RoleDto.class);
 
         assertThat(actualRole.getName()).isEqualTo(expectedRole.getName());
@@ -134,7 +134,7 @@ public class RolesApiTest {
         Membership expectedMembership = DEFAULT_MEMBERSHIP();
         mockGetTeamById(mockServer, ORDINARY_CORAL_LYNX_TEAM_UUID, ORDINARY_CORAL_LYNX_TEAM());
         createMembership(expectedMembership)
-                .statusCode(201);
+                .statusCode(200);
 
         getRole(expectedMembership.getUserId(), expectedMembership.getTeamId())
                 .statusCode(200)
@@ -159,4 +159,5 @@ public class RolesApiTest {
         getRole(GIANNI_USER_UUID, UUID_1)
                 .validate(404, format("Team %s not found", UUID_1));
     }
+
 }

--- a/src/test/java/com/ecore/roles/service/MembershipsServiceTest.java
+++ b/src/test/java/com/ecore/roles/service/MembershipsServiceTest.java
@@ -11,14 +11,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import java.util.Optional;
 
 import static com.ecore.roles.utils.TestData.DEFAULT_MEMBERSHIP;
+import static com.ecore.roles.utils.TestData.UUID_1;
+import static com.ecore.roles.utils.TestData.UUID_2;
 import static com.ecore.roles.utils.TestData.DEVELOPER_ROLE;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
@@ -98,6 +100,38 @@ class MembershipsServiceTest {
     public void shouldFailToGetMembershipsWhenRoleIdIsNull() {
         assertThrows(NullPointerException.class,
                 () -> membershipsService.getMemberships(null));
+    }
+
+    @Test
+    public void shouldFindRolesWithValidUserIdAndTeamId() {
+        Membership expectedMembership = DEFAULT_MEMBERSHIP();
+        Optional<Membership> membership = Optional.of((Membership) expectedMembership);
+        when(membershipRepository.findByUserIdAndTeamId(expectedMembership.getUserId(),
+                expectedMembership.getTeamId()))
+                        .thenReturn(membership);
+
+        var roles = membershipsService.findRolesByUserIdAndTeamId(DEFAULT_MEMBERSHIP().getUserId(),
+                DEFAULT_MEMBERSHIP().getTeamId());
+
+        assertNotNull(roles);
+        assertTrue(roles.size() > 0);
+        assertEquals(roles.get(0).getName(), DEFAULT_MEMBERSHIP().getRole().getName());
+    }
+
+    @Test
+    @MockitoSettings(strictness = Strictness.LENIENT)
+    public void shouldFailFindRolesWithInvalidUserIdAndTeamId() {
+        Membership expectedMembership = DEFAULT_MEMBERSHIP();
+        Optional<Membership> membership = Optional.of((Membership) expectedMembership);
+        when(membershipRepository.findByUserIdAndTeamId(expectedMembership.getUserId(),
+                expectedMembership.getTeamId()))
+                        .thenReturn(membership);
+
+        var roles = membershipsService.findRolesByUserIdAndTeamId(UUID_1,
+                UUID_2);
+
+        assertNotNull(roles);
+        assertTrue(roles.isEmpty());
     }
 
 }

--- a/src/test/java/com/ecore/roles/utils/MockUtils.java
+++ b/src/test/java/com/ecore/roles/utils/MockUtils.java
@@ -33,7 +33,8 @@ public class MockUtils {
 
     public static void mockGetTeamById(MockRestServiceServer mockServer, UUID teamId, Team team) {
         try {
-            mockServer.expect(ExpectedCount.manyTimes(), requestTo("http://test.com/teams/" + teamId))
+
+            mockServer.expect(ExpectedCount.manyTimes(), requestTo("/v1/teams/" + teamId))
                     .andExpect(method(HttpMethod.GET))
                     .andRespond(
                             withStatus(HttpStatus.OK)


### PR DESCRIPTION
**Code changes:**

**Changes:**
-src/test/java/com/ecore/roles/utils/MockUtils.java
the mockServer request to url shuould be changed to "/v1/teams/" because our endpoint does not respond properly to "http://test.com/teams/".

-somes test classes were changed from .statusCode(201) to .statusCode(200)
for sample : src/test/java/com/ecore/roles/api/RolesApiTest.java, because in some points test classes expected  200 status code
resource: https://aloneonahill.com/blog/http-status-codes

-In somes rest controller classes annotations were changed to @GetMapping because we need get data from the server, so get action should be used instead post.
Example: src/main/java/com/ecore/roles/web/rest/TeamsRestController.java


-src/test/java/com/ecore/roles/service/MembershipsServiceTest.java, adding new 2 test 
shouldFindRolesWithValidUserIdAndTeamId
shouldFailFindRolesWithInvalidUserIdAndTeamId
allow me test functionallity of the new endpoint, the second one have a lenient settings because we want to simulate a not found role based in a not existant.

-src/main/java/com/ecore/roles/web/rest/RolesRestController.java
the controller with the new feature endpoint that allow you find the roles based on teammemberid and teamid, it use membership service to get this.

-src/main/java/com/ecore/roles/web/RolesApi.java
adding the new feature endpoint to the contract

**-src/main/java/com/ecore/roles/service/impl/MembershipsServiceImpl.java**
adding findRolesByUserIdAndTeamId service implementation method with the new  feature  it use membershipRepository (extension of JpaRepository) to get the roles it need based on the found memberships, if it brings nothing it will return 404.

-src/main/java/com/ecore/roles/service/MembershipsService.java
adding the new feature endpoint to the service contract

-backend-challenge.postman_collection_victor.json
the new json collection for postman usage.